### PR TITLE
Withdraw event wrong amount bug fix

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "FAI"
-version = "0.9.0"
+version = "1.0.2"
 
 [addresses]
 StarcoinFramework = "0x1"

--- a/sources/modules/pool/STCVaultPoolA.move
+++ b/sources/modules/pool/STCVaultPoolA.move
@@ -221,7 +221,7 @@ module STCVaultPoolA {
             WithdrawEvent {
                 pool_type: Token::token_code<STC::STC>(),
                 withdrawer: Signer::address_of(account),
-                amount: amount
+                amount: withdraw_amount
             });
         withdraw_amount
 

--- a/spectests/TestLiquidation.exp
+++ b/spectests/TestLiquidation.exp
@@ -18,7 +18,7 @@ task 7 'run'. lines 48-68:
 
 task 8 'run'. lines 70-86:
 {
-  "gas_used": 226888,
+  "gas_used": 212741,
   "status": {
     "Keep": "Executed"
   }
@@ -124,7 +124,7 @@ task 20 'run'. lines 245-265:
 
 task 21 'run'. lines 267-283:
 {
-  "gas_used": 232262,
+  "gas_used": 218115,
   "status": {
     "Keep": "Executed"
   }


### PR DESCRIPTION
1. fixed the bug that withdraw event use the wrong amount;
2. upgrade version number;
3. update spectest .exp file;
4. barnard deployed and transaction checked